### PR TITLE
hack: add local platform to bin target

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -46,6 +46,7 @@ target "vendor-update" {
 
 target "bin" {
   target = "bin"
+  platforms = ["local"]
   output = ["type=local,dest=bin"]
 }
 


### PR DESCRIPTION
cc @chris-crone thanks for the report on Mac:

```
➜  go-imageinspect git:(main) docker buildx bake bin
[+] Building 19.4s (22/22) FINISHED                                                                                     
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 3.49kB                                                                             0.0s
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 45B                                                                                   0.0s
 => resolve image config for docker.io/docker/dockerfile:1                                                         1.3s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                   0.0s
 => docker-image://docker.io/docker/dockerfile:1@sha256:d2d74ff22a0e47b21f4bbde337e2ac4cd0a02a2226ef79264878db3dc  0.4s
 => => resolve docker.io/docker/dockerfile:1@sha256:d2d74ff22a0e47b21f4bbde337e2ac4cd0a02a2226ef79264878db3dc7e87  0.0s
 => => sha256:8e1d48261ac9dfac38ca33ae19f221194cec998e4d2504a002545fda69f6b034 9.44MB / 10.82MB                   17.6s
 => => extracting sha256:8e1d48261ac9dfac38ca33ae19f221194cec998e4d2504a002545fda69f6b034                          0.1s
 => [internal] load metadata for docker.io/tonistiigi/xx:1.1.2                                                     1.3s
 => [internal] load metadata for docker.io/library/golang:1.19-alpine                                              1.3s
 => [auth] tonistiigi/xx:pull token for registry-1.docker.io                                                       0.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                      0.0s
 => [base 1/3] FROM docker.io/library/golang:1.19-alpine@sha256:2381c1e5f8350a901597d633b2e517775eeac7a6682be3922  4.1s
 => => resolve docker.io/library/golang:1.19-alpine@sha256:2381c1e5f8350a901597d633b2e517775eeac7a6682be39225a93b  0.0s
 => => extracting sha256:da3aa66ae7ca151fbd33126b15fa4d01bd5ceb35d53de36a8c6c82ecde58b596                          0.0s
 => => sha256:491d6e59a2be619159e6630fabdf81f0255c275176cd97d109fa2f417935d6a8 116.39MB / 116.88MB                15.3s
 => => extracting sha256:491d6e59a2be619159e6630fabdf81f0255c275176cd97d109fa2f417935d6a8                          1.9s
 => => extracting sha256:cb4d12be79e26ab534722d5e8e5c9d931ed5ebd84ded16cae4b12390bb543502                          0.0s
 => [internal] load build context                                                                                  0.0s
 => => transferring context: 179.20kB                                                                              0.0s
 => [xx 1/1] FROM docker.io/tonistiigi/xx:1.1.2@sha256:9dde7edeb9e4a957ce78be9f8c0fbabe0129bf5126933cd3574888f443  0.1s
 => => resolve docker.io/tonistiigi/xx:1.1.2@sha256:9dde7edeb9e4a957ce78be9f8c0fbabe0129bf5126933cd3574888f443731  0.0s
 => => extracting sha256:6b9f00cd577380cfa5d5a8d5ebf82f91f7aa469401818e4de53b2a16dd4a1642                          0.0s
 => [base 2/3] RUN apk add --no-cache cpio findutils git linux-headers                                             2.3s
 => [base 3/3] WORKDIR /src                                                                                        0.0s
 => [build-base 1/3] COPY --link --from=xx / /                                                                     0.0s
 => => merging                                                                                                     0.0s
 => [build-base 2/3] COPY go.* .                                                                                   0.0s
 => [build-base 3/3] RUN --mount=type=cache,target=/go/pkg/mod     --mount=type=cache,target=/root/.cache/go-buil  4.5s
 => [build-bin 1/1] RUN --mount=type=bind,target=.     --mount=type=cache,target=/root/.cache     --mount=type=ca  4.2s
 => [bin 1/1] COPY --from=build-bin /usr/bin/imageinspect ./                                                       0.0s
 => exporting to client                                                                                            0.2s
 => => copying files 11.53MB                                                                                       0.2s
➜  go-imageinspect git:(main) ./bin/imageinspect moby/buildkit:latest
zsh: exec format error: ./bin/imageinspect
```